### PR TITLE
Add API key input with IndexedDB

### DIFF
--- a/src/main/webapp/chatgpt-to-find-authors-websites/website-addresses-searcher.html
+++ b/src/main/webapp/chatgpt-to-find-authors-websites/website-addresses-searcher.html
@@ -1,22 +1,29 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <title>Website addresses searcher</title>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <head>
+        <title>JavaScript documentation</title>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-    <!-- Bootstrap / JQuery / Knockout. -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css" />
-    <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/knockout/3.5.0/knockout-min.js"></script>
-</head>
-<body class="container mt-3">
+        <!-- Bootstrap / JQuery / Knockout. -->
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css" integrity="sha384-xOolHFLEh07PJGoPkLv1IbcEPTNtaed2xpHsD9ESMhqIYd0nLMwNLD69Npy4HI+N" crossorigin="anonymous" />
+        <script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js" integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.min.js" integrity="sha384-+sLIOodYLS7CIrQpBjl+C7nPvqq+FbNUBDunl/OZv93DB7Ln/533i8e/mZXLi/P+" crossorigin="anonymous"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/knockout/3.5.0/knockout-min.js"></script>
+    </head>
+    <body class="container mt-3">
 <h1 class="h2 mb-3 mt-5">Website addresses searcher</h1>
 <h5 class="mb-4">OpenAPI 4O with web search enabled</h5>
 
 <form>
+    <!-- API key field -->
+    <div class="input-group mb-3">
+        <div class="input-group-prepend">
+            <label class="input-group-text">API Key</label>
+        </div>
+        <input type="password" data-bind="value: apiKey" class="form-control" />
+    </div>
     <!-- Prompt selector -->
     <div class="mb-3">
         <span class="mr-2 font-weight-bold">Prompt type:</span>
@@ -65,22 +72,54 @@
 </div>
 
 <script>
-	const apiKey = "the-key";
-	
-	async function askChatGpt(messages) {
-		const apiRequest = new Request("https://api.openai.com/v1/chat/completions", {
-			method: "POST",
-			headers: {
-				Authorization: `Bearer ${apiKey}`,
-				"Content-Type": "application/json"
-			},
-			body: JSON.stringify(
-					{
-						model: "gpt-4o-search-preview",
-						messages: messages
-					}
-			)
-		});
+        function openDb() {
+                return new Promise(function (resolve, reject) {
+                        const req = indexedDB.open("websiteSearch", 1);
+                        req.onupgradeneeded = function (e) {
+                                const db = e.target.result;
+                                if (!db.objectStoreNames.contains("config")) {
+                                        db.createObjectStore("config");
+                                }
+                        };
+                        req.onsuccess = function (e) { resolve(e.target.result); };
+                        req.onerror = function (e) { reject(e.target.error); };
+                });
+        }
+
+        async function loadApiKey() {
+                const db = await openDb();
+                return new Promise(function (resolve, reject) {
+                        const tx = db.transaction("config", "readonly");
+                        const req = tx.objectStore("config").get("apiKey");
+                        req.onsuccess = function () { resolve(req.result || ""); };
+                        req.onerror = function (e) { reject(e.target.error); };
+                });
+        }
+
+        async function saveApiKey(key) {
+                const db = await openDb();
+                return new Promise(function (resolve, reject) {
+                        const tx = db.transaction("config", "readwrite");
+                        tx.objectStore("config").put(key, "apiKey");
+                        tx.oncomplete = function () { resolve(); };
+                        tx.onerror = function (e) { reject(e.target.error); };
+                });
+        }
+
+        async function askChatGpt(messages, apiKey) {
+                const apiRequest = new Request("https://api.openai.com/v1/chat/completions", {
+                        method: "POST",
+                        headers: {
+                                Authorization: `Bearer ${apiKey}`,
+                                "Content-Type": "application/json"
+                        },
+                        body: JSON.stringify(
+                                        {
+                                                model: "gpt-4o-search-preview",
+                                                messages: messages
+                                        }
+                        )
+                });
 	
 		let answer;
 		try {
@@ -145,10 +184,19 @@ No comments, details, descriptions, or notes.`;
         };
 
         /* ---------- observables ---------- */
+        self.apiKey       = ko.observable('');
         self.selectedPrompt = ko.observable('single');
         self.query        = ko.observable(userPrompts.single);   // USER textarea
         self.systemPrompt = ko.observable(systemPrompts.single); // SYSTEM textarea (NEW)
         self.answer       = ko.observable("");
+
+        loadApiKey().then(function (key) {
+            self.apiKey(key);
+        });
+
+        self.apiKey.subscribe(function (val) {
+            saveApiKey(val);
+        });
 
         /* when the radio button changes, update BOTH textareas */
         self.selectedPrompt.subscribe(function (key) {
@@ -161,8 +209,8 @@ No comments, details, descriptions, or notes.`;
             const userMsg    = self.query().trim();
             const systemMsg  = self.systemPrompt().trim();
 
-            if (!userMsg || !systemMsg) {
-                self.answer("Please fill both prompt fields.");
+            if (!userMsg || !systemMsg || !self.apiKey().trim()) {
+                self.answer("Please fill API key and both prompt fields.");
                 return;
             }
 
@@ -175,7 +223,7 @@ No comments, details, descriptions, or notes.`;
             ];
 
             /* askChatGpt now receives the ready-made array */
-            askChatGpt(messages)
+            askChatGpt(messages, self.apiKey())
                 .then(self.answer)
                 .catch(function (err) {
                     console.error(err);


### PR DESCRIPTION
## Summary
- add standard header to `website-addresses-searcher.html`
- add API key password field
- implement IndexedDB helpers to save and load the key
- use the stored key when calling OpenAI API

## Testing
- `npm test` *(fails: qunit not found)*

------
https://chatgpt.com/codex/tasks/task_b_6862a271460c832bb743addafa802479