### PR TITLE
Add link to website search page

### DIFF
--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -17,6 +17,7 @@
         <ul class="list-group">
             <li class="list-group-item"><a href="./serper-dev-caller/index.html">Serper.dev Caller</a></li>
             <li class="list-group-item"><a href="./fix-invalid-google-ids/index.html">Fix Invalid Google IDs</a></li>
+            <li class="list-group-item"><a href="./chatgpt-to-find-authors-websites/website-addresses-searcher.html">Website Addresses Searcher</a></li>
             <li class="list-group-item"><a href="./test/index.html">Unit Tests</a></li>
         </ul>
     </body>


### PR DESCRIPTION
## Summary
- update `index.html` with link to the Website Addresses Searcher page

## Testing
- `npx qunit src/main/webapp/test/test.js` *(fails: needs package installation)*
- `xdg-open src/main/webapp/test/index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6862b26ba8fc832bbd8563c1fd94e3c0