### PR TITLE
Fix web_search payload format

### DIFF
--- a/src/main/webapp/chatgpt-to-find-authors-websites/responses-utils.js
+++ b/src/main/webapp/chatgpt-to-find-authors-websites/responses-utils.js
@@ -1,8 +1,11 @@
-function buildResponsesBody(query) {
+function buildResponsesBody(systemPrompt, userPrompt) {
     return {
         model: 'gpt-4o',
         tools: [{ type: 'web_search' }],
-        input: query
+        messages: [
+            { role: 'system', content: systemPrompt },
+            { role: 'user', content: userPrompt }
+        ]
     };
 }
 

--- a/src/main/webapp/chatgpt-to-find-authors-websites/website-addresses-web-search.html
+++ b/src/main/webapp/chatgpt-to-find-authors-websites/website-addresses-web-search.html
@@ -94,14 +94,14 @@
             });
         }
 
-        async function askWebSearch(question, apiKey) {
+        async function askWebSearch(systemMsg, userMsg, apiKey) {
             const apiRequest = new Request('https://api.openai.com/v1/responses', {
                 method: 'POST',
                 headers: {
                     'Authorization': 'Bearer ' + apiKey,
                     'Content-Type': 'application/json'
                 },
-                body: JSON.stringify(buildResponsesBody(question))
+                body: JSON.stringify(buildResponsesBody(systemMsg, userMsg))
             });
 
             let answer;
@@ -149,7 +149,8 @@ Authors:
 When you DO find a site, respond with only the URL \u2014 no other text.
 No comments, details, descriptions, or notes.`;
 
-            const systemPromptForMultipleAuthors = `If an author has no personal website, write: NOT FOUND.
+            const systemPromptForMultipleAuthors = `For each of the listed authors, perform a web search.
+If an author has no personal website, write: NOT FOUND.
 Return only the URL or NOT FOUND, one line per author, like:
 [Author]: [URL|NOT FOUND]
 
@@ -188,8 +189,7 @@ No comments, details, descriptions, or notes.`;
                 }
 
                 self.answer('Query has been sent to chatbot. Waiting answer \u2026');
-                var question = composeQuery(systemMsg, userMsg);
-                askWebSearch(question, self.apiKey())
+                askWebSearch(systemMsg, userMsg, self.apiKey())
                     .then(self.answer)
                     .catch(function(err){
                         console.error(err);

--- a/src/main/webapp/test/test-browser.js
+++ b/src/main/webapp/test/test-browser.js
@@ -51,11 +51,13 @@ QUnit.test('joins values with new lines', assert => {
 
 QUnit.module('buildResponsesBody');
 QUnit.test('creates body for web search', assert => {
-  const q = 'test query';
-  const body = buildResponsesBody(q);
+  const body = buildResponsesBody('sys', 'user');
   assert.equal(body.model, 'gpt-4o');
   assert.deepEqual(body.tools, [{ type: 'web_search' }]);
-  assert.equal(body.input, q);
+  assert.deepEqual(body.messages, [
+    { role: 'system', content: 'sys' },
+    { role: 'user', content: 'user' }
+  ]);
 });
 
 QUnit.module('composeQuery');


### PR DESCRIPTION
## Summary
- use messages array in web search requests
- include new instruction in system prompt
- adjust form to send separate system and user prompts
- update unit tests for new buildResponsesBody

## Testing
- `npm test` *(fails: qunit not found)*

------
https://chatgpt.com/codex/tasks/task_b_6862c1e79fac832b80fb94e8feead159