### PR TITLE
Fix website search request

### DIFF
--- a/src/main/webapp/chatgpt-to-find-authors-websites/responses-utils.js
+++ b/src/main/webapp/chatgpt-to-find-authors-websites/responses-utils.js
@@ -2,10 +2,7 @@ function buildResponsesBody(systemPrompt, userPrompt) {
     return {
         model: 'gpt-4o',
         tools: [{ type: 'web_search' }],
-        messages: [
-            { role: 'system', content: systemPrompt },
-            { role: 'user', content: userPrompt }
-        ]
+        input: composeQuery(systemPrompt, userPrompt)
     };
 }
 

--- a/src/main/webapp/test/test-browser.js
+++ b/src/main/webapp/test/test-browser.js
@@ -54,10 +54,7 @@ QUnit.test('creates body for web search', assert => {
   const body = buildResponsesBody('sys', 'user');
   assert.equal(body.model, 'gpt-4o');
   assert.deepEqual(body.tools, [{ type: 'web_search' }]);
-  assert.deepEqual(body.messages, [
-    { role: 'system', content: 'sys' },
-    { role: 'user', content: 'user' }
-  ]);
+  assert.equal(body.input, 'sys\nuser');
 });
 
 QUnit.module('composeQuery');


### PR DESCRIPTION
## Summary
- update `buildResponsesBody` to use the new `input` field for the Responses API
- adjust tests for the updated helper

## Testing
- `npm test` *(fails: qunit not found)*
- `npx qunit src/main/webapp/test/test-browser.js` *(fails: needs to install qunit)*
- `npx qunit src/main/webapp/test/test.js` *(fails: needs to install qunit)*

------
https://chatgpt.com/codex/tasks/task_b_6862c8074670832ba2990de806db27e5