### PR TITLE
Support new CID tab format

### DIFF
--- a/src/main/webapp/fix-invalid-google-ids/fix-by-cid.html
+++ b/src/main/webapp/fix-invalid-google-ids/fix-by-cid.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        <title>Fix by CID</title>
+        <title>JavaScript documentation</title>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
@@ -27,6 +27,7 @@
                 <tr>
                     <th>ID</th>
                     <th>GOOGLE_PLACE_ID</th>
+                    <th>CID</th>
                     <th>NAME</th>
                     <th>ADDRESS</th>
                     <th>CITY</th>
@@ -41,6 +42,7 @@
                 <tr>
                     <td data-bind="text: ID"></td>
                     <td data-bind="text: GOOGLE_PLACE_ID"></td>
+                    <td data-bind="text: CID"></td>
                     <td data-bind="text: NAME"></td>
                     <td data-bind="text: ADDRESS"></td>
                     <td data-bind="text: CITY"></td>

--- a/src/main/webapp/fix-invalid-google-ids/fix-by-name-and-address.html
+++ b/src/main/webapp/fix-invalid-google-ids/fix-by-name-and-address.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        <title>Fix by name and address</title>
+        <title>JavaScript documentation</title>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
@@ -27,6 +27,7 @@
                 <tr>
                     <th>ID</th>
                     <th>GOOGLE_PLACE_ID</th>
+                    <th>CID</th>
                     <th>NAME</th>
                     <th>ADDRESS</th>
                     <th>CITY</th>
@@ -41,6 +42,7 @@
                 <tr>
                     <td data-bind="text: ID"></td>
                     <td data-bind="text: GOOGLE_PLACE_ID"></td>
+                    <td data-bind="text: CID"></td>
                     <td data-bind="text: NAME"></td>
                     <td data-bind="text: ADDRESS"></td>
                     <td data-bind="text: CITY"></td>

--- a/src/main/webapp/fix-invalid-google-ids/utils.js
+++ b/src/main/webapp/fix-invalid-google-ids/utils.js
@@ -4,7 +4,19 @@ function parseTabText(text) {
   const header = lines[0].split('\t');
   const hasHeader = header[0] === 'ID';
   const start = hasHeader ? 1 : 0;
-  const cols = ['ID','GOOGLE_PLACE_ID','NAME','ADDRESS','CITY','STATE','ZIP','IS_VALID_MANUAL','IS_VALID','SEARCH_QUERY','JSON_DATA_FROM_GOOGLE_MAP'];
+
+  const colsOld = ['ID','GOOGLE_PLACE_ID','NAME','ADDRESS','CITY','STATE','ZIP','IS_VALID_MANUAL','IS_VALID','SEARCH_QUERY','JSON_DATA_FROM_GOOGLE_MAP'];
+  const colsNew = ['ID','GOOGLE_PLACE_ID','CID','NAME','ADDRESS','CITY','STATE','ZIP','SEARCH_QUERY','JSON_DATA_FROM_GOOGLE_MAP'];
+
+  let useNew = false;
+  if (hasHeader) {
+    useNew = header.includes('CID');
+  } else {
+    const parts = lines[0].split('\t');
+    useNew = parts.length === colsNew.length;
+  }
+
+  const cols = useNew ? colsNew : colsOld;
   const records = [];
   for (let i = start; i < lines.length; i++) {
     const parts = lines[i].split('\t');
@@ -21,6 +33,15 @@ function parseTabText(text) {
         obj[c] = val;
       }
     });
+
+    if (useNew) {
+      obj.IS_VALID_MANUAL = '';
+      if (typeof ko !== 'undefined' && typeof ko.observable === 'function') {
+        obj.IS_VALID = ko.observable('');
+      } else {
+        obj.IS_VALID = '';
+      }
+    }
     records.push(obj);
   }
   return records;

--- a/src/main/webapp/test/test-browser.js
+++ b/src/main/webapp/test/test-browser.js
@@ -10,9 +10,10 @@ QUnit.test('splits and trims lines', assert => {
 
 QUnit.module('parseTabText');
 QUnit.test('parses tab separated lines', assert => {
-  const text = 'ID\tGOOGLE_PLACE_ID\tNAME\n1\ta\tfoo';
+  const text = 'ID\tGOOGLE_PLACE_ID\tCID\tNAME\n1\ta\tcid1\tfoo';
   const result = parseTabText(text);
   assert.equal(result.length, 1);
+  assert.equal(result[0].CID, 'cid1');
   assert.equal(result[0].NAME, 'foo');
   assert.equal(typeof result[0].IS_VALID, 'function', 'IS_VALID is observable');
 });
@@ -20,8 +21,8 @@ QUnit.test('parses tab separated lines', assert => {
 QUnit.module('validateRecords');
 QUnit.test('marks matching name as valid', assert => {
   const recs = [
-    {ID:'1', GOOGLE_PLACE_ID:'a', NAME:'Foo', ADDRESS:'', CITY:'X', STATE:'S', ZIP:'', IS_VALID_MANUAL:'', IS_VALID: ko.observable(''), SEARCH_QUERY:'q', JSON_DATA_FROM_GOOGLE_MAP:'{"places":[{"title":"Foo","address":"addr"}]}'},
-    {ID:'2', GOOGLE_PLACE_ID:'b', NAME:'Bar', ADDRESS:'', CITY:'X', STATE:'S', ZIP:'', IS_VALID_MANUAL:'', IS_VALID: ko.observable(''), SEARCH_QUERY:'q', JSON_DATA_FROM_GOOGLE_MAP:'{"places":[{"title":"Foo","address":"addr"}]}'}
+    {ID:'1', GOOGLE_PLACE_ID:'a', CID:'c1', NAME:'Foo', ADDRESS:'', CITY:'X', STATE:'S', ZIP:'', IS_VALID_MANUAL:'', IS_VALID: ko.observable(''), SEARCH_QUERY:'q', JSON_DATA_FROM_GOOGLE_MAP:'{"places":[{"title":"Foo","address":"addr"}]}'},
+    {ID:'2', GOOGLE_PLACE_ID:'b', CID:'c2', NAME:'Bar', ADDRESS:'', CITY:'X', STATE:'S', ZIP:'', IS_VALID_MANUAL:'', IS_VALID: ko.observable(''), SEARCH_QUERY:'q', JSON_DATA_FROM_GOOGLE_MAP:'{"places":[{"title":"Foo","address":"addr"}]}'}
   ];
   validateRecords(recs);
   assert.equal(recs[0].IS_VALID(), '1');
@@ -30,8 +31,8 @@ QUnit.test('marks matching name as valid', assert => {
 
 QUnit.test('clears values when all are invalid', assert => {
   const recs = [
-    {ID:'1', GOOGLE_PLACE_ID:'a', NAME:'Foo', ADDRESS:'', CITY:'X', STATE:'S', ZIP:'', IS_VALID_MANUAL:'', IS_VALID: ko.observable(''), SEARCH_QUERY:'w', JSON_DATA_FROM_GOOGLE_MAP:'{"places":[]}'},
-    {ID:'2', GOOGLE_PLACE_ID:'b', NAME:'Bar', ADDRESS:'', CITY:'X', STATE:'S', ZIP:'', IS_VALID_MANUAL:'', IS_VALID: ko.observable(''), SEARCH_QUERY:'w', JSON_DATA_FROM_GOOGLE_MAP:'{"places":[]}'}
+    {ID:'1', GOOGLE_PLACE_ID:'a', CID:'c1', NAME:'Foo', ADDRESS:'', CITY:'X', STATE:'S', ZIP:'', IS_VALID_MANUAL:'', IS_VALID: ko.observable(''), SEARCH_QUERY:'w', JSON_DATA_FROM_GOOGLE_MAP:'{"places":[]}'},
+    {ID:'2', GOOGLE_PLACE_ID:'b', CID:'c2', NAME:'Bar', ADDRESS:'', CITY:'X', STATE:'S', ZIP:'', IS_VALID_MANUAL:'', IS_VALID: ko.observable(''), SEARCH_QUERY:'w', JSON_DATA_FROM_GOOGLE_MAP:'{"places":[]}'}
   ];
   validateRecords(recs);
   assert.equal(recs[0].IS_VALID(), '');

--- a/src/main/webapp/test/test.js
+++ b/src/main/webapp/test/test.js
@@ -32,10 +32,11 @@ import { parseTabText, validateRecords } from '../fix-invalid-google-ids/utils.j
 module('parseTabText');
 
 test('parses tab separated lines', assert => {
-  const text = 'ID\tGOOGLE_PLACE_ID\tNAME\n1\ta\tfoo';
+  const text = 'ID\tGOOGLE_PLACE_ID\tCID\tNAME\n1\ta\tc1\tfoo';
   const result = parseTabText(text);
   assert.equal(result.length, 1);
   assert.equal(result[0].ID, '1');
+  assert.equal(result[0].CID, 'c1');
   assert.equal(result[0].NAME, 'foo');
 });
 
@@ -43,8 +44,8 @@ module('validateRecords');
 
 test('marks matching name as valid', assert => {
   const recs = [
-    {ID:'1', GOOGLE_PLACE_ID:'a', NAME:'Foo', ADDRESS:'', CITY:'X', STATE:'S', ZIP:'', IS_VALID_MANUAL:'', IS_VALID:'', SEARCH_QUERY:'q', JSON_DATA_FROM_GOOGLE_MAP:'{"places":[{"title":"Foo","address":"addr"}]}'},
-    {ID:'2', GOOGLE_PLACE_ID:'b', NAME:'Bar', ADDRESS:'', CITY:'X', STATE:'S', ZIP:'', IS_VALID_MANUAL:'', IS_VALID:'', SEARCH_QUERY:'q', JSON_DATA_FROM_GOOGLE_MAP:'{"places":[{"title":"Foo","address":"addr"}]}'}
+    {ID:'1', GOOGLE_PLACE_ID:'a', CID:'c1', NAME:'Foo', ADDRESS:'', CITY:'X', STATE:'S', ZIP:'', IS_VALID_MANUAL:'', IS_VALID:'', SEARCH_QUERY:'q', JSON_DATA_FROM_GOOGLE_MAP:'{"places":[{"title":"Foo","address":"addr"}]}'},
+    {ID:'2', GOOGLE_PLACE_ID:'b', CID:'c2', NAME:'Bar', ADDRESS:'', CITY:'X', STATE:'S', ZIP:'', IS_VALID_MANUAL:'', IS_VALID:'', SEARCH_QUERY:'q', JSON_DATA_FROM_GOOGLE_MAP:'{"places":[{"title":"Foo","address":"addr"}]}'}
   ];
   validateRecords(recs);
   assert.equal(recs[0].IS_VALID, '1');
@@ -53,8 +54,8 @@ test('marks matching name as valid', assert => {
 
 test('clears values when all are invalid', assert => {
   const recs = [
-    {ID:'1', GOOGLE_PLACE_ID:'a', NAME:'Foo', ADDRESS:'', CITY:'X', STATE:'S', ZIP:'', IS_VALID_MANUAL:'', IS_VALID:'', SEARCH_QUERY:'w', JSON_DATA_FROM_GOOGLE_MAP:'{"places":[]}'},
-    {ID:'2', GOOGLE_PLACE_ID:'b', NAME:'Bar', ADDRESS:'', CITY:'X', STATE:'S', ZIP:'', IS_VALID_MANUAL:'', IS_VALID:'', SEARCH_QUERY:'w', JSON_DATA_FROM_GOOGLE_MAP:'{"places":[]}'}
+    {ID:'1', GOOGLE_PLACE_ID:'a', CID:'c1', NAME:'Foo', ADDRESS:'', CITY:'X', STATE:'S', ZIP:'', IS_VALID_MANUAL:'', IS_VALID:'', SEARCH_QUERY:'w', JSON_DATA_FROM_GOOGLE_MAP:'{"places":[]}'},
+    {ID:'2', GOOGLE_PLACE_ID:'b', CID:'c2', NAME:'Bar', ADDRESS:'', CITY:'X', STATE:'S', ZIP:'', IS_VALID_MANUAL:'', IS_VALID:'', SEARCH_QUERY:'w', JSON_DATA_FROM_GOOGLE_MAP:'{"places":[]}'}
   ];
   validateRecords(recs);
   assert.equal(recs[0].IS_VALID, '');


### PR DESCRIPTION
## Summary
- handle both old and new tab-separated formats with optional CID column
- show CID column in fix-by pages
- adjust headers to match other pages
- update unit tests for new structure

## Testing
- `npx qunit src/main/webapp/test/test.js` *(fails: module export error)*

------
https://chatgpt.com/codex/tasks/task_b_6865c05bc3d4832bad045ba49c876ea5