### PR TITLE
Add CID validation logic

### DIFF
--- a/src/main/webapp/fix-invalid-google-ids/manual-parse.js
+++ b/src/main/webapp/fix-invalid-google-ids/manual-parse.js
@@ -8,7 +8,7 @@ function AppViewModel() {
   };
 
   this.validate = () => {
-    // no validation logic required
+    validateRecordsByCid(this.records());
   };
 
   this.copyIsValid = () => {

--- a/src/main/webapp/test/test-browser.js
+++ b/src/main/webapp/test/test-browser.js
@@ -40,6 +40,27 @@ QUnit.test('clears values when all are invalid', assert => {
   assert.equal(recs[1].IS_VALID(), '');
 });
 
+QUnit.module('validateRecordsByCid');
+QUnit.test('skips group with identical cid', assert => {
+  const recs = [
+    {ID:'1', GOOGLE_PLACE_ID:'x', CID:'111', NAME:'A', ADDRESS:'', CITY:'', STATE:'', ZIP:'', IS_VALID: ko.observable(''), SEARCH_QUERY:'', JSON_DATA_FROM_GOOGLE_MAP:'{}'},
+    {ID:'2', GOOGLE_PLACE_ID:'x', CID:'111', NAME:'B', ADDRESS:'', CITY:'', STATE:'', ZIP:'', IS_VALID: ko.observable(''), SEARCH_QUERY:'', JSON_DATA_FROM_GOOGLE_MAP:'{}'}
+  ];
+  validateRecordsByCid(recs);
+  assert.equal(recs[0].IS_VALID(), '');
+  assert.equal(recs[1].IS_VALID(), '');
+});
+
+QUnit.test('marks record matching json cid', assert => {
+  const recs = [
+    {ID:'1', GOOGLE_PLACE_ID:'y', CID:'123', NAME:'A', ADDRESS:'', CITY:'', STATE:'', ZIP:'', IS_VALID: ko.observable(''), SEARCH_QUERY:'', JSON_DATA_FROM_GOOGLE_MAP:'{"places":[{"cid":"456"}]}'},
+    {ID:'2', GOOGLE_PLACE_ID:'y', CID:'456', NAME:'B', ADDRESS:'', CITY:'', STATE:'', ZIP:'', IS_VALID: ko.observable(''), SEARCH_QUERY:'', JSON_DATA_FROM_GOOGLE_MAP:'{"places":[{"cid":"456"}]}'}
+  ];
+  validateRecordsByCid(recs);
+  assert.equal(recs[0].IS_VALID(), '0');
+  assert.equal(recs[1].IS_VALID(), '1');
+});
+
 QUnit.module('collectIsValid');
 QUnit.test('joins values with new lines', assert => {
   const recs = [

--- a/src/main/webapp/test/test.js
+++ b/src/main/webapp/test/test.js
@@ -27,7 +27,7 @@ test('returns cached result on second call', async assert => {
   assert.equal(r1, 'a-result', 'first result matches');
   assert.equal(r2, 'a-result', 'second result matches cached value');
 });
-import { parseTabText, validateRecords } from '../fix-invalid-google-ids/utils.js';
+import { parseTabText, validateRecords, validateRecordsByCid } from '../fix-invalid-google-ids/utils.js';
 
 module('parseTabText');
 
@@ -61,5 +61,27 @@ test('clears values when all are invalid', assert => {
   validateRecords(recs);
   assert.equal(recs[0].IS_VALID, '');
   assert.equal(recs[1].IS_VALID, '');
+});
+
+module('validateRecordsByCid');
+
+test('skips group with identical cid', assert => {
+  const recs = [
+    {ID:'1', GOOGLE_PLACE_ID:'x', CID:'111', NAME:'A', ADDRESS:'', CITY:'', STATE:'', ZIP:'', IS_VALID:'', SEARCH_QUERY:'', JSON_DATA_FROM_GOOGLE_MAP:'{}'},
+    {ID:'2', GOOGLE_PLACE_ID:'x', CID:'111', NAME:'B', ADDRESS:'', CITY:'', STATE:'', ZIP:'', IS_VALID:'', SEARCH_QUERY:'', JSON_DATA_FROM_GOOGLE_MAP:'{}'}
+  ];
+  validateRecordsByCid(recs);
+  assert.equal(recs[0].IS_VALID, '');
+  assert.equal(recs[1].IS_VALID, '');
+});
+
+test('marks record matching json cid', assert => {
+  const recs = [
+    {ID:'1', GOOGLE_PLACE_ID:'y', CID:'123', NAME:'A', ADDRESS:'', CITY:'', STATE:'', ZIP:'', IS_VALID:'', SEARCH_QUERY:'', JSON_DATA_FROM_GOOGLE_MAP:'{"places":[{"cid":"456"}]}'},
+    {ID:'2', GOOGLE_PLACE_ID:'y', CID:'456', NAME:'B', ADDRESS:'', CITY:'', STATE:'', ZIP:'', IS_VALID:'', SEARCH_QUERY:'', JSON_DATA_FROM_GOOGLE_MAP:'{"places":[{"cid":"456"}]}'}
+  ];
+  validateRecordsByCid(recs);
+  assert.equal(recs[0].IS_VALID, '0');
+  assert.equal(recs[1].IS_VALID, '1');
 });
 


### PR DESCRIPTION
## Summary
- implement `validateRecordsByCid` in utils and export it
- hook Validate button on CID page to new logic
- add QUnit coverage for CID validation

## Testing
- `npx qunit src/main/webapp/test/test.js` *(fails: Need to install packages)*
- `npx qunit src/main/webapp/test/index.html` *(fails to load HTML via CLI)*

------
https://chatgpt.com/codex/tasks/task_b_6865cbb3521c832b82afeae3a3a10795