### PR TITLE
Update matching rules

### DIFF
--- a/src/main/webapp/fix-invalid-google-ids/utils.js
+++ b/src/main/webapp/fix-invalid-google-ids/utils.js
@@ -47,6 +47,13 @@ function parseTabText(text) {
   return records;
 }
 
+function normalizeString(str) {
+  return (str || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9 ]+/gi, '');
+}
+
 function validateRecords(records) {
   const groups = new Map();
   for (const rec of records) {
@@ -67,7 +74,7 @@ function validateRecords(records) {
     }));
     const titleMatches = parsed.filter(p => {
       const place = p.json.places && p.json.places[0];
-      return place && place.title === p.rec.NAME;
+      return place && normalizeString(place.title) === normalizeString(p.rec.NAME);
     });
 
     if (titleMatches.length === 1) {
@@ -79,7 +86,7 @@ function validateRecords(records) {
       const addressMatches = titleMatches.filter(p => {
         const place = p.json.places && p.json.places[0];
         if (!place || !p.rec.ADDRESS) return false;
-        return place.address.startsWith(p.rec.ADDRESS);
+        return normalizeString(place.address).startsWith(normalizeString(p.rec.ADDRESS));
       });
       if (addressMatches.length >= 1) {
         const chosen = addressMatches[0].rec;

--- a/src/main/webapp/test/test-browser.js
+++ b/src/main/webapp/test/test-browser.js
@@ -30,6 +30,16 @@ QUnit.test('marks matching name as valid', assert => {
   assert.equal(recs[1].IS_VALID(), '0');
 });
 
+QUnit.test('ignores case and punctuation when matching', assert => {
+  const recs = [
+    {ID:'1', GOOGLE_PLACE_ID:'a', CID:'', NAME:'ACME, Inc.', ADDRESS:'123 Main St.', CITY:'X', STATE:'S', ZIP:'', IS_VALID: ko.observable(''), SEARCH_QUERY:'x', JSON_DATA_FROM_GOOGLE_MAP:'{"places":[{"title":"acme inc","address":"123 main st suite"}]}'},
+    {ID:'2', GOOGLE_PLACE_ID:'b', CID:'', NAME:'Other', ADDRESS:'', CITY:'X', STATE:'S', ZIP:'', IS_VALID: ko.observable(''), SEARCH_QUERY:'x', JSON_DATA_FROM_GOOGLE_MAP:'{"places":[{"title":"acme inc","address":"123 main st suite"}]}'}
+  ];
+  validateRecords(recs);
+  assert.equal(recs[0].IS_VALID(), '1');
+  assert.equal(recs[1].IS_VALID(), '0');
+});
+
 QUnit.test('clears values when all are invalid', assert => {
   const recs = [
     {ID:'1', GOOGLE_PLACE_ID:'a', CID:'c1', NAME:'Foo', ADDRESS:'', CITY:'X', STATE:'S', ZIP:'', IS_VALID: ko.observable(''), SEARCH_QUERY:'w', JSON_DATA_FROM_GOOGLE_MAP:'{"places":[]}'},

--- a/src/main/webapp/test/test.js
+++ b/src/main/webapp/test/test.js
@@ -53,6 +53,16 @@ test('marks matching name as valid', assert => {
   assert.equal(recs[1].IS_VALID, '0');
 });
 
+test('ignores case and punctuation when matching', assert => {
+  const recs = [
+    {ID:'1', GOOGLE_PLACE_ID:'a', CID:'', NAME:'ACME, Inc.', ADDRESS:'123 Main St.', CITY:'X', STATE:'S', ZIP:'', IS_VALID:'', SEARCH_QUERY:'x', JSON_DATA_FROM_GOOGLE_MAP:'{"places":[{"title":"acme inc","address":"123 main st suite"}]}'},
+    {ID:'2', GOOGLE_PLACE_ID:'b', CID:'', NAME:'Other', ADDRESS:'', CITY:'X', STATE:'S', ZIP:'', IS_VALID:'', SEARCH_QUERY:'x', JSON_DATA_FROM_GOOGLE_MAP:'{"places":[{"title":"acme inc","address":"123 main st suite"}]}'}
+  ];
+  validateRecords(recs);
+  assert.equal(recs[0].IS_VALID, '1');
+  assert.equal(recs[1].IS_VALID, '0');
+});
+
 test('clears values when all are invalid', assert => {
   const recs = [
     {ID:'1', GOOGLE_PLACE_ID:'a', CID:'c1', NAME:'Foo', ADDRESS:'', CITY:'X', STATE:'S', ZIP:'', IS_VALID:'', SEARCH_QUERY:'w', JSON_DATA_FROM_GOOGLE_MAP:'{"places":[]}'},


### PR DESCRIPTION
## Summary
- add `normalizeString` helper to sanitize text before comparison
- update validation rules to match names and addresses ignoring case and punctuation
- extend tests in browser and Node versions for the new normalization

## Testing
- `npm test` *(fails: qunit not found)*
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_b_6865d6f82e28832bb2ddaa30a6368bf0