### PR TITLE
Fix NEW_DATA parsing

### DIFF
--- a/src/main/webapp/fix-invalid-google-ids/utils.js
+++ b/src/main/webapp/fix-invalid-google-ids/utils.js
@@ -42,6 +42,12 @@ function parseTabText(text) {
         obj.IS_VALID = '';
       }
     }
+
+    if (typeof ko !== 'undefined' && typeof ko.observable === 'function') {
+      obj.NEW_DATA = ko.observable('');
+    } else {
+      obj.NEW_DATA = '';
+    }
     records.push(obj);
   }
   return records;


### PR DESCRIPTION
## Summary
- ensure NEW_DATA field exists immediately after parsing records

## Testing
- `npx qunit src/main/webapp/test/test.js` *(fails: needs package installation)*

------
https://chatgpt.com/codex/tasks/task_b_68666bfbd690832bb1647edb2c94a5b5