### PR TITLE
Update fix-by-name-and-address logic

### DIFF
--- a/src/main/webapp/fix-invalid-google-ids/utils.js
+++ b/src/main/webapp/fix-invalid-google-ids/utils.js
@@ -79,6 +79,25 @@ function recordExistsInJson(rec) {
   return false;
 }
 
+function findPlaceInJson(rec) {
+  try {
+    const json = JSON.parse(rec.JSON_DATA_FROM_GOOGLE_MAP);
+    const places = json.places || [];
+    for (const place of places) {
+      if (normalizeString(place.title) === normalizeString(rec.NAME)) {
+        if (!rec.ADDRESS) return place;
+        if (place.address &&
+            normalizeString(place.address).startsWith(normalizeString(rec.ADDRESS))) {
+          return place;
+        }
+      }
+    }
+  } catch (e) {
+    // ignore parse errors
+  }
+  return null;
+}
+
 function validateRecords(records) {
   const groups = new Map();
   for (const rec of records) {
@@ -248,6 +267,16 @@ function populateNewData(records) {
         }
       } catch (e) {
         // ignore parse errors
+      }
+    } else if (getIsValid(rec) === '3') {
+      const place = findPlaceInJson(rec);
+      if (place) {
+        const text = JSON.stringify(place);
+        if (typeof rec.NEW_DATA === 'function') {
+          rec.NEW_DATA(text);
+        } else {
+          rec.NEW_DATA = text;
+        }
       }
     }
   }

--- a/src/main/webapp/test/test-browser.js
+++ b/src/main/webapp/test/test-browser.js
@@ -126,6 +126,18 @@ QUnit.test('leaves empty when invalid', assert => {
   assert.equal(rec.NEW_DATA(), '');
 });
 
+QUnit.test('selects matching place when value is 3', assert => {
+  const data = '{"places":[{"title":"Foo","address":"A"},{"title":"Foo","address":"B"}]}';
+  const rec = {
+    NAME: 'Foo',
+    ADDRESS: 'B',
+    JSON_DATA_FROM_GOOGLE_MAP: data,
+    IS_VALID: ko.observable('3')
+  };
+  populateNewData([rec]);
+  assert.equal(rec.NEW_DATA(), '{"title":"Foo","address":"B"}');
+});
+
 QUnit.module('collectNewData');
 QUnit.test('joins NEW_DATA values with new lines', assert => {
   const recs = [


### PR DESCRIPTION
## Summary
- handle IS_VALID `3` values when filling NEW_DATA
- test new matching logic for value `3`

## Testing
- `no tests`

------
https://chatgpt.com/codex/tasks/task_b_686704756810832ba7b4612f421074a8